### PR TITLE
fix: resolve to text if body is empty

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -146,7 +146,11 @@ module.exports = {
 
   _onResponse: function (options, err, res) {
     if (res && res.ok === true && !err) {
-      options.resolve(res.body);
+      if (Object.keys(res.body).length !== 0) {
+        options.resolve(res.body)
+      } else {
+        options.resolve(res.text)
+      }
     } else {
       var isStatus401 = res && res.status === 401;
       var hasResBody = res && res.body;


### PR DESCRIPTION
Some types of files like text/plain populate the `.text` property instead of `body`. This change chekcs if the body is populated and if it is not then reverts to `.text`